### PR TITLE
Smartcard readers with PIN pads

### DIFF
--- a/src/pam_p11.c
+++ b/src/pam_p11.c
@@ -173,7 +173,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 		password = NULL;
 	} else {
 		/* get password */
-		sprintf(password_prompt, "Password for token %.32s ",
+		sprintf(password_prompt, "Password for token %.32s: ",
 			slot->token->label);
 
 		/* ask the user for the password if variable text is set */


### PR DESCRIPTION
Allow for chipcard/smartcard readers with a PINpad as commonly used in banking and the medical sector. 

Have the driver follow policy to determine that the PIN is only to be entered on the PIN pad of the reader as opposed to the keyboard.
