### PR TITLE
Fix compilation error with GCC 9 + LTO on 64bit

### DIFF
--- a/src/match_openssh.c
+++ b/src/match_openssh.c
@@ -150,7 +150,7 @@ static EVP_PKEY *ssh1_line_to_key(char *line)
 	return NULL;
 }
 
-extern int sc_base64_decode(const char *in, unsigned char *out, size_t outlen);
+extern int sc_base64_decode(const char *in, unsigned char *out, unsigned int outlen);
 
 static EVP_PKEY *ssh2_line_to_key(char *line)
 {


### PR DESCRIPTION
Fix "lto-type-mismatch" error raised when `size_t` is defined as `unsigned long` and not `unsigned int`. This is the case e.g. with GCC 9 on x86_64.

Example of build failure on openSUSE:
```
[   24s] match_openssh.c:153:12: error: type of 'sc_base64_decode' does not match original declaration [-Werror=lto-type-mismatch]
[   24s]   153 | extern int sc_base64_decode(const char *in, unsigned char *out, size_t outlen);
[   24s]       |            ^
[   24s] base64.c:74:5: note: type mismatch in parameter 3
[   24s]    74 | int sc_base64_decode(const char *in, unsigned char *out, unsigned int outlen)
[   24s]       |     ^
[   24s] base64.c:74:5: note: type 'unsigned int' should match type 'size_t'
[   24s] base64.c:74:5: note: 'sc_base64_decode' was previously declared here
[   24s] base64.c:74:5: note: code may be misoptimized unless '-fno-strict-aliasing' is used
[   24s] lto1: all warnings being treated as errors
[   24s] lto-wrapper: fatal error: gcc returned 1 exit status
[   24s] compilation terminated.
[   24s] /usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: error: lto-wrapper failed
```
(Full log available at: https://build.opensuse.org/build/openSUSE:Factory/standard/x86_64/pam_p11/_log.)