### PR TITLE
Use EVP_PKEY_size() to allocate correct size of signature buffer.

### DIFF
--- a/src/pam_p11.c
+++ b/src/pam_p11.c
@@ -636,13 +636,19 @@ static int key_verify(pam_handle_t *pamh, int flags, PKCS11_KEY *authkey)
 	int ok = 0;
 	unsigned char challenge[30];
 	unsigned char *signature = NULL;
-	unsigned int siglen = sizeof signature;
+	unsigned int siglen;
 	const EVP_MD *md = EVP_sha1();
 	EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 	EVP_PKEY *privkey = PKCS11_get_private_key(authkey);
 	EVP_PKEY *pubkey = PKCS11_get_public_key(authkey);
 
-	if (NULL == (signature = malloc(EVP_PKEY_size(privkey))))
+	if (NULL == privkey)
+		goto err;
+	siglen = EVP_PKEY_size(privkey);
+	if (siglen <= 0)
+		goto err;
+	signature = malloc(siglen);
+	if (NULL == signature)
 		goto err;
 
 	/* Verify a SHA-1 hash of random data, signed by the key.

--- a/src/pam_p11.c
+++ b/src/pam_p11.c
@@ -677,8 +677,7 @@ static int key_verify(pam_handle_t *pamh, int flags, PKCS11_KEY *authkey)
 	ok = 1;
 
 err:
-	if (NULL != signature)
-		free(signature);
+	free(signature);
 	if (NULL != pubkey)
 		EVP_PKEY_free(pubkey);
 	if (NULL != privkey)


### PR DESCRIPTION
Do not use fixed buffer size for signature, EVP_SignFinal() requires
buffer for signature at least  EVP_PKEY_size(pkey) bytes in size.