### PR TITLE
match_openssh: Fix the build for LibreSSL >= 3.0.0

### DIFF
--- a/src/match_openssh.c
+++ b/src/match_openssh.c
@@ -22,7 +22,8 @@
 
 #define OPENSSH_LINE_MAX 16384	/* from openssh SSH_MAX_PUBKEY_BYTES */
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined (LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
+    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3000000L)
 void RSA_get0_key(const RSA *r,
                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
 {


### PR DESCRIPTION
Newer LibreSSL versions no longer need the older OpenSSL APIs.