### PR TITLE
application "test-login" in CI - functional test.

### DIFF
--- a/.github/ci-test.sh
+++ b/.github/ci-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+SOPIN="12345678"
+PIN="123456"
+
+make
+
+P11LIB=/usr/lib/softhsm/libsofthsm2.so
+
+echo "directories.tokendir = .tokens/" > .softhsm2.conf
+export SOFTHSM2_CONF=".softhsm2.conf"
+
+mkdir -p $HOME/.ssh
+
+
+for KEY in RSA:2048 EC:secp256r1 EC:secp384r1 EC:secp521r1; do
+	rm -rf .tokens
+	mkdir .tokens
+
+	softhsm2-util --init-token --slot 0 --label "SC test" --so-pin="$SOPIN" --pin="$PIN"
+
+	# ubuntu 20.04, ssh-keygen is unable to extract EC key if --id is not specified
+	#
+	# ssh-keygen -D /usr/lib/softhsm/libsofthsm2.so
+	# xmalloc: zero size
+
+	pkcs11-tool --module="$P11LIB" --keypairgen --key-type=$KEY --login --pin=$PIN --id 01
+
+	ssh-keygen -D $P11LIB >> $HOME/.ssh/authorized_keys
+	echo $PIN | sudo -E src/test-login $P11LIB $(whoami)
+done
+
+rm -rf .tokens
+rm .softhsm2.conf

--- a/.github/setup-libressl.sh
+++ b/.github/setup-libressl.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex -o xtrace
+
+V=libressl-3.6.1
+
+# keep libp11-dev installed!
+sudo dpkg --purge --force-depends libssl-dev
+
+if [ ! -d "$V" ]; then
+	# letsencrypt CA does not seem to be included in CI runner
+	wget --no-check-certificate https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$V.tar.gz
+	tar xzf $V.tar.gz
+fi
+pushd $V
+./configure --prefix=/usr/local
+make -j $(nproc)
+sudo make install
+popd
+
+# update dynamic linker to find the libraries in non-standard path
+echo "/usr/local/lib64" | sudo tee /etc/ld.so.conf.d/openssl.conf
+sudo ldconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - '**.in'
       - '**.po'
       - .github/workflows/ci.yml
+      - .github/ci-test.sh
   push:
 
 
@@ -28,9 +29,18 @@ jobs:
         name: pam_p11
         path:
           pam_p11*.tar.gz
+    - run: sudo apt install softhsm2 opensc
+    - run: .github/ci-test.sh
 
   ubuntu-22:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - run: .github/build.sh ubuntu
+    - run: sudo apt install softhsm2 opensc
+    - name: upgrading broken libp11 (using libp11 from lunar)
+      run: |
+       echo "deb http://us.archive.ubuntu.com/ubuntu/ lunar main"|sudo tee -a /etc/apt/sources.list
+       sudo apt update
+       sudo apt install libp11-3 libp11-dev
+    - run: .github/ci-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,22 @@ jobs:
   macos:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: .github/build.sh macos
 
   ubuntu:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: .github/build.sh ubuntu
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pam_p11
         path:
           pam_p11*.tar.gz
+
+  ubuntu-22:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - run: .github/build.sh ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,17 @@ jobs:
        sudo apt update
        sudo apt install libp11-3 libp11-dev
     - run: .github/ci-test.sh
+
+  ubuntu-22-libressl:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - run: .github/build.sh ubuntu
+    - run: sudo apt install softhsm2 opensc
+    - name: upgrading broken libp11 (using libp11 from lunar)
+      run: |
+       echo "deb http://us.archive.ubuntu.com/ubuntu/ lunar main"|sudo tee -a /etc/apt/sources.list
+       sudo apt update
+       sudo apt install libp11-3 libp11-dev
+    - run: .github/setup-libressl.sh
+    - run: .github/ci-test.sh

--- a/src/match_openssh.c
+++ b/src/match_openssh.c
@@ -63,7 +63,7 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 
 #endif
 
-static EVP_PKEY *init_evp_pkey_rsa(BIGNUM *rsa_e, BIGNUM *rsa_n)
+static EVP_PKEY *init_evp_pkey_rsa(BIGNUM *rsa_n, BIGNUM *rsa_e)
 {
 	EVP_PKEY *key = NULL;
 

--- a/src/match_openssh.c
+++ b/src/match_openssh.c
@@ -111,31 +111,24 @@ static EVP_PKEY *init_evp_pkey_rsa(BIGNUM *rsa_n, BIGNUM *rsa_e)
 	return key;
 }
 
-static EVP_PKEY *init_evp_pkey_ec(int nid_curve, BIGNUM *pub_x, BIGNUM *pub_y)
+static EVP_PKEY *init_evp_pkey_ec(int nid_curve, const unsigned char *buf, size_t len)
 {
 	EVP_PKEY *key = NULL;
 
-	if (!pub_x || !pub_y)
-		return NULL;
-
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
-	key = EVP_PKEY_new();
-	if (!key)
-		return NULL;
+	BN_CTX *ctx = NULL;
+	EC_KEY *ec_key = NULL;
 
-	EC_KEY *ec_key = EC_KEY_new_by_curve_name(nid_curve);
-	if (!ec_key) {
-		EVP_PKEY_free(key);
-		return NULL;
-	}
-
-	/* do error checking here: valid x, y, ec_key, point on curve.. */
-	if (!EC_KEY_set_public_key_affine_coordinates(ec_key, pub_x, pub_y)) {
+	if ((key = EVP_PKEY_new()) == NULL
+			|| (ctx = BN_CTX_new()) == NULL
+			|| (ec_key = EC_KEY_new_by_curve_name(nid_curve)) == NULL
+			|| (1 != EC_KEY_oct2key(ec_key, buf, len, ctx))
+			|| (1 != EVP_PKEY_assign_EC_KEY(key, ec_key))) {
 		EC_KEY_free(ec_key);
+		BN_CTX_free(ctx);
 		EVP_PKEY_free(key);
 		return NULL;
 	}
-	EVP_PKEY_assign_EC_KEY(key, ec_key);
 #else
 	OSSL_PARAM_BLD *bld = NULL;
 	OSSL_PARAM *params = NULL;
@@ -158,8 +151,7 @@ static EVP_PKEY *init_evp_pkey_ec(int nid_curve, BIGNUM *pub_x, BIGNUM *pub_y)
 	if ((pctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL)) == NULL
 			|| (bld = OSSL_PARAM_BLD_new()) == NULL
 			|| !OSSL_PARAM_BLD_push_utf8_string(bld, OSSL_PKEY_PARAM_GROUP_NAME, group_name, 0)
-			|| !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_X, pub_x)
-			|| !OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_EC_PUB_Y, pub_y)
+			|| !OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY, buf, len)
 			|| (params = OSSL_PARAM_BLD_to_param(bld)) == NULL
 			|| EVP_PKEY_fromdata_init(pctx) <= 0
 			|| EVP_PKEY_fromdata(pctx, &key, EVP_PKEY_PUBLIC_KEY, params) <= 0) {
@@ -351,10 +343,6 @@ err:
 
 static EVP_PKEY *ssh_nistp_line_to_key(char *line)
 {
-	EVP_PKEY *key;
-	BIGNUM *x;
-	BIGNUM *y;
-
 	unsigned char decoded[OPENSSH_LINE_MAX];
 	int len;
 	int flen;
@@ -438,22 +426,8 @@ static EVP_PKEY *ssh_nistp_line_to_key(char *line)
 	/* check uncompressed indicator */
 	if (decoded[i] != 4 )
 		return NULL;
-	i++;
 
-	/* read point coordinates */
-	x = BN_bin2bn(decoded + i, flen, NULL);
-	i += flen;
-	y = BN_bin2bn(decoded + i, flen, NULL);
-
-	key = init_evp_pkey_ec(nid, x, y);
-	if (!key) {
-		if (x)
-			BN_free(x);
-		if (y)
-			BN_free(y);
-	}
-
-	return key;
+	return init_evp_pkey_ec(nid, decoded + i, len);
 }
 
 extern int match_user_openssh(EVP_PKEY *authkey, const char *login)

--- a/src/test.c
+++ b/src/test.c
@@ -58,8 +58,12 @@ int main(int argc, const char **argv)
 
 	/* initialize default values */
 	strcpy(module, LIBDIR "/opensc-pkcs11.so");
-	if (0 != getlogin_r(user, sizeof user))
-		goto err;
+	if (argc < 3) {
+		if (0 != getlogin_r(user, sizeof user)) {
+			perror("getlogin_r");
+			goto err;
+		}
+	}
 
 	switch (argc) {
 		case 3:


### PR DESCRIPTION
There are several patches in this PR related to:

- build on ubuntu 22 (openssl 3.x)
- "test-login"  functional test (using softhsm, RSA:2048 EC:secp256r1 EC:secp384r1 EC:secp521r1)
- fixes for openssl 3.x (comparison of EC and RSA keys)
- libressl support for EC keys fixed + "test-login"  functional test 