### PR TITLE
Update pam_p11.c - key_login() always succeeded

### DIFF
--- a/src/pam_p11.c
+++ b/src/pam_p11.c
@@ -699,8 +699,10 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 		goto err;
 	}
 
-	if (1 != key_login(pamh, flags, authslot, pin_regex))
+	if (1 != key_login(pamh, flags, authslot, pin_regex)) {
+		r = PAM_AUTH_ERR;
 		goto err;
+	}
 
 	if (authkey == NULL && authcert) {
 		if (NULL == (authkey = PKCS11_find_key(authcert))) {

--- a/src/pam_p11.c
+++ b/src/pam_p11.c
@@ -700,7 +700,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 	}
 
 	if (1 != key_login(pamh, flags, authslot, pin_regex)) {
-		r = PAM_AUTH_ERR;
+		r = PAM_CRED_INSUFFICIENT;
 		goto err;
 	}
 


### PR DESCRIPTION
key_login always succeeded even if PIN input was incorrect. r = PAM_SUCCESS set prior to key_login() and didn't get changed to a failure if key_login() failed. 